### PR TITLE
Set up behave testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: python
 python:
   - "2.7"
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 install:
   - ./bootstrap.py
 script:
   - make
+  - make behave

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,11 @@ jenkins: ./ve/bin/python flake8 jshint jscs validate test
 test: ./ve/bin/python
 	$(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc
 
+behave: ./ve/bin/python
+	$(MANAGE) behave
+
 flake8: ./ve/bin/python
-	$(FLAKE8) $(APP) gate_block curveball --max-complexity=10 --exclude=migrations
+	$(FLAKE8) $(APP) gate_block curveball features --max-complexity=10 --exclude=migrations
 
 jshint: node_modules/jshint/bin/jshint
 	./node_modules/jshint/bin/jshint media/js/uelc_admin

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,17 @@
+from behave_django import environment
+from splinter import Browser
+
+from uelc.main.tests.factories import UELCCaseQuizModuleFactory
+
+
+def before_all(context):
+    context.browser = Browser('firefox')
+    UELCCaseQuizModuleFactory()
+
+
+def before_scenario(context, scenario):
+    environment.before_scenario(context, scenario)
+
+
+def after_scenario(context, scenario):
+    environment.after_scenario(context, scenario)

--- a/features/index.feature
+++ b/features/index.feature
@@ -1,0 +1,4 @@
+Feature: Index Page
+  Scenario: Index Page Load
+    When I visit "/"
+    Then I get a 200 HTTP response

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -1,0 +1,11 @@
+from behave import then, when
+
+
+@when(u'I visit "{url}"')
+def i_visit(context, url):
+    context.browser.visit(context.base_url + url)
+
+
+@then(u'I get a {status_code} HTTP response')
+def i_get_a_http_response(context, status_code):
+    assert context.browser.status_code == int(status_code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,10 @@ gunicorn==19.3.0
 django-infranil==0.1.0
 django-flatblocks==0.9
 djangorestframework==2.4.5
+
+parse==1.6.6  # for behave
+parse-type==0.3.4  # for behave
+enum34==1.0.4  # for behave
+behave==1.2.5
+behave-django==0.1.3
+splinter==0.7.2

--- a/uelc/main/tests/factories.py
+++ b/uelc/main/tests/factories.py
@@ -107,12 +107,16 @@ class LibraryItemFactory(factory.DjangoModelFactory):
 class UELCModuleFactory(object):
     '''Stealing module factory from pagetree factories to adapt for
     casequiz tests'''
-    def __init__(self, hname, base_url):
+    def __init__(self, hname='main', base_url='/pages/'):
         hierarchy = HierarchyFactory(name=hname, base_url=base_url)
         root = hierarchy.get_root()
         r = FakeReq()
-        r.POST = {'description': 'description', 'rhetorical': False,
-                  'allow_redo': True, 'show_submit_state': False}
+        r.POST = {
+            'description': 'description',
+            'rhetorical': False,
+            'allow_redo': True,
+            'show_submit_state': False,
+        }
         casequiz = CaseQuiz.create(r)
         root.add_child_section_from_dict(casequiz.as_dict())
         self.root = root
@@ -121,22 +125,33 @@ class UELCModuleFactory(object):
 class UELCCaseQuizModuleFactory(object):
     '''Stealing module factory from pagetree factories to adapt for
     casequiz tests'''
-    def __init__(self, hname, base_url):
+    def __init__(self, hname='main', base_url='/pages/'):
         hierarchy = HierarchyFactory(name=hname, base_url=base_url)
         root = hierarchy.get_root()
-        root.add_child_section_from_dict(
-            {'label': "One", 'slug': "one",
-             'children': [{'label': "Three", 'slug': "introduction"}]})
+        root.add_child_section_from_dict({
+            'label': "One", 'slug': "one",
+            'children': [
+                {'label': "Three", 'slug': "introduction"}
+            ]
+        })
         root.add_child_section_from_dict({'label': "Two", 'slug': "two"})
         r = FakeReq()
-        r.POST = {'description': 'description', 'rhetorical': 'rhetorical',
-                  'allow_redo': True, 'show_submit_state': False}
+        r.POST = {
+            'description': 'description',
+            'rhetorical': 'rhetorical',
+            'allow_redo': True, 'show_submit_state': False,
+        }
         casequiz = CaseQuiz.create(r)
-        blocks = [{'label': 'Welcome to your new Forest Site',
-                   'css_extra': '',
-                   'block_type': 'Test Block',
-                   'body': 'You should now use the edit link to add content'}]
-        root.add_child_section_from_dict({'label': 'Four', 'slug': 'four',
-                                          'pageblocks': blocks})
+        blocks = [{
+            'label': 'Welcome to your new Forest Site',
+            'css_extra': '',
+            'block_type': 'Test Block',
+            'body': 'You should now use the edit link to add content',
+        }]
+        root.add_child_section_from_dict({
+            'label': 'Four',
+            'slug': 'four',
+            'pageblocks': blocks,
+        })
         root.add_child_section_from_dict(casequiz.as_dict())
         self.root = root

--- a/uelc/settings_shared.py
+++ b/uelc/settings_shared.py
@@ -131,7 +131,7 @@ INSTALLED_APPS = [
     'gate_block',
     'curveball',
     'ckeditor',
-
+    'behave_django',
 ]
 
 PAGEBLOCKS = [


### PR DESCRIPTION
For UELC, I'm trying out the behave-django package instead
of django-behave. The maintainers of behave-django are actively
using it, unlike django-behave, so it's bound to
be a little more responsive to questions like e.g., how to run
a single test:
  https://github.com/django-behave/django-behave/issues/58

Also, django-behave's custom test runner is kind of awkward
because it doesn't clear the database between scenarios, leading
to confusing tests. behave-django claims to address this problem:
  https://github.com/mixxorz/behave-django/wiki/Getting-started#database-transactions-per-scenario

The tests can be run locally with `make behave` and are set
up to run on travis.