### PR TITLE
:arrow_up: Django 1.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ django-statsd-mozilla==0.3.14
 raven==5.2.0
 django-bootstrap3==5.4.0
 django-bootstrap-form==3.2
-django-debug-toolbar==1.3
+django-debug-toolbar==1.3.2
 django-waffle==0.10.1
 django-jenkins==0.17.0
 django-smoketest==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.7.8
+Django==1.8.2
 feedparser==5.1.3
 Markdown==2.6.1
 smartypants==1.6.0.3
@@ -38,7 +38,7 @@ pyzmq==14.6.0
 
 djangowind==0.13.3
 sorl==3.1
-tagging==0.3-pre
+django-tagging==0.4
 typogrify==2.0.7
 django-indexer==0.3.0
 django-templatetag-sugar==0.1
@@ -50,7 +50,7 @@ django-statsd-mozilla==0.3.14
 raven==5.2.0
 django-bootstrap3==5.4.0
 django-bootstrap-form==3.2
-django-debug-toolbar==1.1
+django-debug-toolbar==1.3
 django-waffle==0.10.1
 django-jenkins==0.17.0
 django-smoketest==0.3.0
@@ -58,8 +58,8 @@ django-extensions==1.4.9
 django-stagingcontext==0.1.0
 django-ga-context==0.1.0
 django-impersonate==0.9
-django-registration==1.1
-django-treebeard==2.0
+django-registration-redux==1.2
+django-treebeard==3.0
 django-pagetree==1.1.6
 django-quizblock==1.1.1
 django-pageblocks==1.0.2

--- a/uelc/main/models.py
+++ b/uelc/main/models.py
@@ -108,7 +108,7 @@ class UserProfile(models.Model):
 
     def set_image_upload_permissions(self, user):
         permission_set = Permission.objects.filter(
-            content_type__name="image upload item")
+            content_type__model="imageuploaditem")
         for perm in permission_set:
             if user.is_staff:
                 user.user_permissions.add(perm.pk)

--- a/uelc/settings_shared.py
+++ b/uelc/settings_shared.py
@@ -64,14 +64,14 @@ TEMPLATE_LOADERS = (
 
 TEMPLATE_CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.request',
+    'django.template.context_processors.debug',
+    'django.template.context_processors.request',
     'stagingcontext.staging_processor',
     'gacontext.ga_processor',
     'djangowind.context.context_processor',
-    'django.core.context_processors.static',
+    'django.template.context_processors.static',
     'django.contrib.messages.context_processors.messages',
-    'django.core.context_processors.media'
+    'django.template.context_processors.media'
 )
 
 MIDDLEWARE_CLASSES = (
@@ -82,7 +82,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    'django.middleware.transaction.TransactionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'impersonate.middleware.ImpersonateMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',


### PR DESCRIPTION
I noticed that the test database takes a long time to populate,
making a lot of the trial-and-error testing I'm doing kind of
time-consuming. Django 1.8 makes this a little faster (10 seconds
instead of 20).

    # Django 1.8.2
    $ time ./manage.py test uelc.main.tests.test_models
    Creating test database for alias 'default'...
    ....................................
    ----------------------------------------------------------------------
    Ran 36 tests in 0.229s

    OK
    Destroying test database for alias 'default'...

    real    0m10.633s
    user    0m10.504s
    sys     0m0.128s

    # Django 1.7.8
    $ time ./manage.py test uelc.main.tests.test_models
    Creating test database for alias 'default'...
    ....................................
    ----------------------------------------------------------------------
    Ran 36 tests in 0.231s

    OK
    Destroying test database for alias 'default'...

    real    0m21.456s
    user    0m21.376s
    sys     0m0.092s

After pulling, you might have to fake some of the migrations on your
database, since the registration and tagging libraries needed to be
updated to support Django 1.8, and they now include their own initial
migrations for these apps.
`./manage.py migrate registration --fake`
`./manage.py migrate tagging --fake`