### PR TITLE
Fix error in fresh_grp_token view

### DIFF
--- a/uelc/main/helper_functions.py
+++ b/uelc/main/helper_functions.py
@@ -179,7 +179,7 @@ def gen_token(request, hierarchy_name):
 def fresh_grp_token(request, section_id):
     section = get_object_or_404(Section, pk=section_id)
     return HttpResponse(
-        json.dumps(dict(section=section,
+        json.dumps(dict(section=section.as_dict(),
                         token=gen_group_token(request, section.pk),
                         websockets_base=settings.WINDSOCK_WEBSOCKETS_BASE)),
         content_type='applicaton/json')

--- a/uelc/main/tests/test_views.py
+++ b/uelc/main/tests/test_views.py
@@ -2,8 +2,11 @@ from django.test import TestCase
 from django.test.client import Client
 from pagetree.helpers import get_hierarchy
 
-from factories import GroupUpFactory, AdminUpFactory, \
-    CaseFactory, CohortFactory, FacilitatorUpFactory
+from factories import (
+    GroupUpFactory, AdminUpFactory,
+    CaseFactory, CohortFactory, FacilitatorUpFactory,
+    UELCModuleFactory
+)
 from pagetree.tests.factories import ModuleFactory
 
 
@@ -426,3 +429,12 @@ class TestAdminUserViewContext(TestCase):
         self.assertIn('hierarchies', response.context)
         self.assertIn('cases', response.context)
         self.assertIn('cohorts', response.context)
+
+
+class TestFreshGrpTokenView(TestCase):
+    def setUp(self):
+        UELCModuleFactory()
+
+    def test_get(self):
+        response = self.client.get("/group_user/fresh_token/1/")
+        self.assertEqual(response.status_code, 302)

--- a/uelc/templates/pagetree/page.html
+++ b/uelc/templates/pagetree/page.html
@@ -39,7 +39,7 @@
 <script>
   window.sectionId = '{{section.pk}}';
 	window.username = '{{request.user.username}}';
-	window.freshTokenUrl = '/group_user/fresh_token/';
+	window.freshTokenUrl = '/group_user/fresh_token/{{section.pk}}';
 	window.token = '{{token}}';
 	window.websocketsBase = '{{websockets_base}}';
 </script>

--- a/uelc/urls.py
+++ b/uelc/urls.py
@@ -118,7 +118,7 @@ urlpatterns = patterns(
      'uelc.main.helper_functions.instructor_page'),
     (r'^facilitator/fresh_token/$',
      'uelc.main.helper_functions.fresh_token'),
-    (r'^group_user/fresh_token/$',
+    (r'^group_user/fresh_token/(?P<section_id>\d+)/$',
      'uelc.main.helper_functions.fresh_grp_token'),
     (r'^pages/(?P<hierarchy_name>[-\w]+)/facilitator/(?P<path>.*)$',
      FacilitatorView.as_view()),


### PR DESCRIPTION
Fixes this error at /group_user/fresh_token/:

>  TypeError at /group_user/fresh_token/
>  fresh_grp_token() takes exactly 2 arguments (1 given)

Sentry error: https://sentry.ccnmtl.columbia.edu/sentry-internal/uelc/group/758/