### PR TITLE
add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local_settings.py
 .settings
 .idea
 node_modules
+.python-version


### PR DESCRIPTION
On my laptop I'm using pyenv to handle python versions, which uses a project-specific .python-version
file to determine what python to use.