### PR TITLE
Fix for facilitator page affix feature.

### DIFF
--- a/media/js/uelc_admin/uelc_facilitator.js
+++ b/media/js/uelc_admin/uelc_facilitator.js
@@ -152,7 +152,7 @@ jQuery(document).ready(function() {
 
     var updateWidth = function() {
         var width = $('.gate-sections:first').width();
-        $('.gate-sections .group-name').width(width);
+        $('.gate-sections .group-name:lt(4)').width(width);
     };
 
     $(window).resize(updateWidth);

--- a/uelc/templates/pagetree/facilitator.html
+++ b/uelc/templates/pagetree/facilitator.html
@@ -27,9 +27,11 @@
       <div class="col-sm-3 text-center">
       <!-- user (u.0), gateblocks (u.1), (u.2) user_last_location -->
           <div class="gate-sections" id="group-user-section-{{u.0.id}}">
-
               <div class="group-name panel panel-default"
-                   data-spy="affix" data-offset-top="200">
+                   {% if forloop.counter < 5 %}
+                     data-spy="affix" data-offset-top="200"
+                   {% endif %}
+                   >
                   <div class="panel-body">
                       <h3 class="text-center">
                           <h3 class="facilitator-usrnm">Group {{u.0}}</h3> 


### PR DESCRIPTION
Don't alter group user boxess on facilitator page that aren't
in the main 4 columns.