### PR TITLE
Fix "interrupted while the page was loading" WS error

### DIFF
--- a/media/js/uelc_admin/group_js.js
+++ b/media/js/uelc_admin/group_js.js
@@ -39,6 +39,9 @@ $(function() {
         conn.onopen = function(evt) {
             currentRefresh = defaultRefresh;
         };
+        $(window).on('beforeunload', function() {
+            conn.close();
+        });
     };
 
     var onMessage = function(evt) {

--- a/media/js/uelc_admin/web_socks.js
+++ b/media/js/uelc_admin/web_socks.js
@@ -37,6 +37,9 @@ $(function() {
         conn.onopen = function(evt) {
             currentRefresh = defaultRefresh;
         };
+        $(window).on('beforeunload', function() {
+            conn.close();
+        });
     };
 
     var onMessage = function(evt) {


### PR DESCRIPTION
This fixes an error I was getting in firefox, preventing
the socket notifications from getting through. See:
    https://bugzilla.mozilla.org/show_bug.cgi?id=712329