### PR TITLE
Fix bug where userlocations get corrupted when page slugs are changed

### DIFF
--- a/uelc/main/helper_functions.py
+++ b/uelc/main/helper_functions.py
@@ -202,3 +202,36 @@ def gen_group_token(request, section_pk):
     return '%s:%s:%s:%d:%d:%s:%s' % (username, sub_prefix,
                                      pub_prefix, now, salt,
                                      ip_address, hmc)
+
+
+def fix_user_locations(user, hierarchy):
+    """Account for slug changes on PageTree's UserLocation.
+
+    Remove the user's UserLocations that have outdated slugs.
+    """
+    for loc in user.userlocation_set.all():
+        if hierarchy.find_section_from_path(loc.path) is None:
+            loc.delete()
+
+
+def get_user_last_location(user, hierarchy):
+    """Returns the last Pagetree Section the user has been in."""
+    user_last_loc = user.userlocation_set.first()
+    if user_last_loc is None:
+        return None
+
+    user_last_location = hierarchy.find_section_from_path(
+        user_last_loc.path)
+    if user_last_location is None:
+        # If we can't find the Section from the path, it may be
+        # an outdated path. In that case, fix up the user's
+        # UserLocation set by removing all outdated paths, and
+        # try again.
+        fix_user_locations(user, hierarchy)
+        user_last_loc = user.userlocation_set.first()
+        if user_last_loc is None:
+            return None
+        user_last_location = hierarchy.find_section_from_path(
+            user_last_loc.path)
+
+    return user_last_location

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -19,7 +19,8 @@ from gate_block.models import GateBlock, SectionSubmission, GateSubmission
 from uelc.main.helper_functions import (
     get_root_context, get_user_map, visit_root, gen_group_token,
     has_responses, reset_page, page_submit, admin_ajax_page_submit,
-    gen_token)
+    gen_token, get_user_last_location
+)
 from uelc.mixins import (
     LoggedInMixin, LoggedInFacilitatorMixin,
     SectionMixin, LoggedInMixinAdmin, DynamicHierarchyMixin,
@@ -579,17 +580,7 @@ class FacilitatorView(LoggedInFacilitatorMixin,
             path=hierarchy.base_url)[0]
         user_sections = []
         for user in cohort_users:
-            try:
-                # bug happens when a user has previously navigated to a
-                # section before a slug change. Example: when /intro/part-1/
-                # has been cahnaged to /intro/part1/ when the user visited
-                # the first slug and it no loger exists.
-
-                user_last_path = user.userlocation_set.first().path
-                user_last_location = hierarchy.find_section_from_path(
-                    user_last_path)
-            except AttributeError:
-                user_last_location = None
+            user_last_location = get_user_last_location(user, hierarchy)
 
             um = get_user_map(hierarchy, user)
             part_usermap = hand.get_partchoice_by_usermap(um)


### PR DESCRIPTION
This seems to fix the issue by deleting all UserLocations that have
outdated slugs, if the facilitator view can't find any valid
UserLocations for the user. See the comments.