### PR TITLE
Remove user icon from header - PMT #101972

### DIFF
--- a/media/js/uelc_admin/web_socks.js
+++ b/media/js/uelc_admin/web_socks.js
@@ -104,10 +104,6 @@ $(function() {
             ' pull-right" aria-hidden="true"></span>');
         jQuery(gcs).find('.glyphicon-user').remove();
         sectionBlock.find('.gate-section .panel-body').prepend(groupIcon);
-        // Look for this column's corresponding .group-name box, and
-        // hide the user icon in case it's there.
-        sectionBlock.closest('.col-sm-3').find(
-            '.group-name .user-icon').hide();
     };
     var openGate = function(groupColumnSelector, sectionBlock) {
         var btn = sectionBlock.find('.btn-danger');

--- a/uelc/templates/pagetree/facilitator.html
+++ b/uelc/templates/pagetree/facilitator.html
@@ -41,15 +41,6 @@
                       <h3 class="text-center">
                           <h3 class="facilitator-usrnm">Group {{u.0}}</h3> 
                       </h3>
-                      <div class="user-icon
-                           {# crazy but works #}
-                           {% for sec in u.1 %}
-                           {% if sec.0.pk == u.2.id %}
-                           hidden
-                           {% endif %}
-                           {% endfor %}">
-                          <span class="glyphicon glyphicon-user pull-right" aria-hidden="true"></span>
-                      </div>
                   </div>
               </div>
 


### PR DESCRIPTION
Reverting commit 2cc381ef because the user icon is appearing
whenever a group user logs out, causing confusion.