### PR TITLE
Fix 500 error when updating username - PMT #102122

### DIFF
--- a/uelc/main/tests/test_views.py
+++ b/uelc/main/tests/test_views.py
@@ -281,6 +281,40 @@ class TestAdminBasicViews(TestCase):
             User.objects.filter(
                 username='NewUserThatIsLongerThan30Characters').exists())
 
+    def test_uelc_admin_update_user(self):
+        up = GroupUpFactory()
+        request = self.client.post(
+            "/uelcadmin/edituser/",
+            {
+                'user_id': up.pk,
+                'username': 'some_random_name',
+                'profile_type': up.profile_type,
+                'cohort': up.cohort.pk,
+            },
+            follow=True)
+        self.assertEqual(request.status_code, 200)
+        self.assertTrue(
+            User.objects.filter(username='some_random_name').exists())
+
+    def test_uelc_admin_update_user_long_username(self):
+        up = GroupUpFactory()
+        original_username = up.user.username
+        long_username = 'some_random_name_longer_than_30_characters'
+        request = self.client.post(
+            "/uelcadmin/edituser/",
+            {
+                'user_id': up.pk,
+                'username': long_username,
+                'profile_type': up.profile_type,
+                'cohort': up.cohort.pk,
+            },
+            follow=True)
+        self.assertEqual(request.status_code, 200)
+        self.assertFalse(
+            User.objects.filter(username=long_username).exists())
+        self.assertTrue(
+            User.objects.filter(username=original_username).exists())
+
     def test_uelc_admin_create_case(self):
         request = self.client.post(
             "/uelcadmin/createcase/",

--- a/uelc/main/tests/test_views.py
+++ b/uelc/main/tests/test_views.py
@@ -286,7 +286,7 @@ class TestAdminBasicViews(TestCase):
         request = self.client.post(
             "/uelcadmin/edituser/",
             {
-                'user_id': up.pk,
+                'user_id': up.user.pk,
                 'username': 'some_random_name',
                 'profile_type': up.profile_type,
                 'cohort': up.cohort.pk,

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -686,7 +686,7 @@ class UELCAdminCreateUserView(
         if error is not None:
             messages.error(request, error, extra_tags='createUserViewError')
 
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -706,7 +706,7 @@ class UELCAdminDeleteUserView(LoggedInMixinAdmin,
                       delete superuser accounts.")
             messages.error(request, action_args['error'],
                            extra_tags='deleteSuperUser')
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -716,7 +716,16 @@ class UELCAdminEditUserView(LoggedInMixinAdmin,
     extra_context = dict()
 
     def post(self, request):
+        url = request.META.get('HTTP_REFERER')
+
         username = request.POST.get('username', '')
+        if len(username) > 30:
+            messages.error(
+                request,
+                'The username needs to be 30 characters or fewer.',
+                extra_tags='createUserViewError')
+            return HttpResponseRedirect(url)
+
         user_id = request.POST.get('user_id', '')
         profile = request.POST.get('profile_type', '')
         cohort_id = request.POST.get('cohort', '')
@@ -735,7 +744,6 @@ class UELCAdminEditUserView(LoggedInMixinAdmin,
         user.profile.set_image_upload_permissions(user)
         user.username = username
         user.save()
-        url = request.META['HTTP_REFERER']
         return HttpResponseRedirect(url)
 
 
@@ -780,14 +788,14 @@ class UELCAdminCreateHierarchyView(LoggedInMixinAdmin,
                           or create one with a different name and url.")
                 messages.error(request, action_args['error'],
                                extra_tags='createCaseViewError')
-                url = request.META['HTTP_REFERER']
+                url = request.META.get('HTTP_REFERER')
                 return HttpResponseRedirect(url)
 
             hier = Hierarchy.objects.create(
                 base_url=url,
                 name=name)
             hier.save()
-            url = request.META['HTTP_REFERER']
+            url = request.META.get('HTTP_REFERER')
             return HttpResponseRedirect(url)
 
 
@@ -799,7 +807,7 @@ class UELCAdminDeleteHierarchyView(LoggedInMixinAdmin,
         hierarchy_id = request.POST.get('hierarchy_id')
         hier = Hierarchy.objects.get(id=hierarchy_id)
         hier.delete()
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -858,7 +866,7 @@ class UELCAdminCreateCohortView(LoggedInMixinAdmin,
             messages.error(request, action_args['error'],
                            extra_tags='createCohortViewError')
 
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -877,7 +885,7 @@ class UELCAdminDeleteCohortView(LoggedInMixinAdmin,
             user.profile.cohort = None
             user.profile.save()
         cohort.delete()
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -911,7 +919,7 @@ class UELCAdminEditCohortView(LoggedInMixinAdmin,
             messages.error(request, action_args['error'],
                            extra_tags='editCohortViewError')
 
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -933,7 +941,7 @@ class UELCAdminCreateCaseView(LoggedInMixinAdmin,
                       Please use existing case or rename.")
             messages.error(request, action_args['error'],
                            extra_tags='createCaseViewError')
-            url = request.META['HTTP_REFERER']
+            url = request.META.get('HTTP_REFERER')
             return HttpResponseRedirect(url)
         if case_exists_hier.exists():
             action_args = dict(
@@ -944,7 +952,7 @@ class UELCAdminCreateCaseView(LoggedInMixinAdmin,
                       an existing case?")
             messages.error(request, action_args['error'],
                            extra_tags='createCaseViewError')
-            url = request.META['HTTP_REFERER']
+            url = request.META.get('HTTP_REFERER')
             return HttpResponseRedirect(url)
         if hierarchy == "" or cohort == "":
             action_args = dict(
@@ -952,7 +960,7 @@ class UELCAdminCreateCaseView(LoggedInMixinAdmin,
                       cohort is selected")
             messages.error(request, action_args['error'],
                            extra_tags='createCaseViewError')
-            url = request.META['HTTP_REFERER']
+            url = request.META.get('HTTP_REFERER')
             return HttpResponseRedirect(url)
 
         hier_obj = Hierarchy.objects.get(id=hierarchy)
@@ -962,7 +970,7 @@ class UELCAdminCreateCaseView(LoggedInMixinAdmin,
             description=description,
             hierarchy=hier_obj)
         case.cohort.add(coh_obj)
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -974,7 +982,7 @@ class UELCAdminDeleteCaseView(LoggedInMixinAdmin,
         case_id = request.POST.get('case_id')
         case = Case.objects.get(id=case_id)
         case.delete()
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 
@@ -997,7 +1005,7 @@ class UELCAdminEditCaseView(LoggedInMixinAdmin,
                       Please use existing case or rename.")
             messages.error(request, action_args['error'],
                            extra_tags='createCaseViewError')
-            url = request.META['HTTP_REFERER']
+            url = request.META.get('HTTP_REFERER')
             return HttpResponseRedirect(url)
         if case_exists_hier.count() > 1:
             action_args = dict(
@@ -1008,7 +1016,7 @@ class UELCAdminEditCaseView(LoggedInMixinAdmin,
                       an existing case?")
             messages.error(request, action_args['error'],
                            extra_tags='createCaseViewError')
-            url = request.META['HTTP_REFERER']
+            url = request.META.get('HTTP_REFERER')
             return HttpResponseRedirect(url)
         if hierarchy == "" or cohorts == "":
             action_args = dict(
@@ -1025,7 +1033,7 @@ class UELCAdminEditCaseView(LoggedInMixinAdmin,
         case.cohort.clear()
         case.cohort.add(*coh_obj)
         case.save()
-        url = request.META['HTTP_REFERER']
+        url = request.META.get('HTTP_REFERER')
         return HttpResponseRedirect(url)
 
 

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -729,7 +729,16 @@ class UELCAdminEditUserView(LoggedInMixinAdmin,
         user_id = request.POST.get('user_id', '')
         profile = request.POST.get('profile_type', '')
         cohort_id = request.POST.get('cohort', '')
-        user = User.objects.get(pk=user_id)
+
+        try:
+            user = User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            messages.error(
+                request,
+                'User not found.',
+                extra_tags='createUserViewError')
+            return HttpResponseRedirect(url)
+
         if cohort_id:
             cohort = Cohort.objects.get(id=cohort_id)
         else:


### PR DESCRIPTION
Adds some tests to the edit user view, and fixes a bug
that occurs when the username is long.