### PR TITLE
Remove djangorestframework since it's not being used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,6 @@ django-pageblocks==1.0.3
 gunicorn==19.3.0
 django-infranil==0.1.0
 django-flatblocks==0.9.1
-djangorestframework==2.4.5
 
 parse==1.6.6  # for behave
 parse-type==0.3.4  # for behave

--- a/uelc/settings_shared.py
+++ b/uelc/settings_shared.py
@@ -106,7 +106,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'sorl.thumbnail',
     'django.contrib.admin',
-    'rest_framework',
     'tagging',
     'typogrify',
     'compressor',
@@ -206,13 +205,6 @@ LOGGING = {
 
 ACCOUNT_ACTIVATION_DAYS = 7
 
-REST_FRAMEWORK = {
-    'DEFAULT_MODEL_SERIALIZER_CLASS':
-    'rest_framework.serializers.ModelSerializer',
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
-    ]
-}
 
 WINDSOCK_BROKER_URL = "tcp://localhost:5555"
 ZMQ_APPNAME = "uelc"

--- a/uelc/urls.py
+++ b/uelc/urls.py
@@ -1,11 +1,8 @@
 from django.conf.urls import patterns, include, url
-from django.contrib.auth.models import User
 from django.contrib import admin
 from django.conf import settings
 from django.views.generic import TemplateView
-from rest_framework import routers, serializers, viewsets
 from uelc.main import views
-from uelc.main.models import UserProfile
 from uelc.main.views import (
     UELCPageView, UELCEditView, FacilitatorView, UELCAdminView,
     UELCAdminCohortView, UELCAdminCreateHierarchyView,
@@ -37,41 +34,12 @@ if hasattr(settings, 'CAS_BASE'):
                          {'next_page': redirect_after_logout})
 
 
-# Serializers define the API representation.
-class UserProfileSerializer(serializers.ModelSerializer):
-    cohorts = serializers.Field()
-
-    class Meta:
-        model = UserProfile
-        fields = ('profile_type', 'cohorts',)
-
-
-class UserSerializer(serializers.HyperlinkedModelSerializer):
-    profile = UserProfileSerializer(many=False)
-
-    class Meta:
-        model = User
-        fields = ("url", "username", "email", "profile")
-
-
-# ViewSets define the view behavior.
-class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
-
-
-router = routers.DefaultRouter()
-router.register(r'user', UserViewSet)
-
 urlpatterns = patterns(
     '',
 
     logout_page,
     admin_logout_page,
     auth_urls,
-    url(r'^api/', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls',
-                               namespace='rest_framework')),
     (r'^registration/', include('registration.backends.default.urls')),
     (r'^$', views.IndexView.as_view()),
     (r'^ckeditor/', include('ckeditor.urls')),


### PR DESCRIPTION
The only api endpoint set up was broken:
https://sentry.ccnmtl.columbia.edu/sentry-internal/uelc/group/828/

But we didn't notice since nothing is using it.