### PR TITLE
Add ptyprocess

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ cssselect==0.9.1
 lxml==3.4.4
 fuzzywuzzy==0.8.0
 sure==1.2.24
+ptyprocess==0.5
 ipdb==0.8.1
 traitlets==4.0.0
 ipython_genutils==0.1.0


### PR DESCRIPTION
using ipdb on uelc, I got the error: "No module named ptyprocess"

The error comes from `pexpect`:

/home/nnyby/src/d/uelc/ve/local/lib/python2.7/site-packages/pexpect/pty_spawn.py in <module>, line 11