### PR TITLE
Use base_url instead of name for hierarchies - PMT #103917

### DIFF
--- a/features/admin.feature
+++ b/features/admin.feature
@@ -5,7 +5,7 @@ Feature: Admin
     Then I see the text "Hello"
 
     When I visit "/pages/doesnt-exist/"
-    Then I see the text "No hierarchy named doesnt-exist found"
+    Then I see the text "No hierarchy with url /pages/doesnt-exist/ found"
 
     When I visit "/pages/case-test/"
     Then I see the text "Test Edit Facilitator Scratchpad"

--- a/uelc/main/tests/test_views.py
+++ b/uelc/main/tests/test_views.py
@@ -844,13 +844,35 @@ class CloneHierarchyWithCasesViewTest(TestCase):
         })
 
         self.assertEqual(r.status_code, 302)
-        self.assertEqual(Hierarchy.objects.filter(name='test').count(), 1)
 
         cloned_h = Hierarchy.objects.get(name='test')
+        self.assertEqual(cloned_h.base_url, '/pages/test/')
         self.assertEqual(Case.objects.filter(hierarchy=cloned_h).count(), 1)
 
         cloned_case = Case.objects.filter(hierarchy=cloned_h).first()
         self.assertEqual(cloned_case.name, 'test')
+        self.assertEqual(cloned_case.description, self.case.description)
+        self.assertEqual(cloned_case.cohort.count(), self.case.cohort.count())
+        self.assertEqual(set(cloned_case.cohort.all()),
+                         set(self.case.cohort.all()))
+
+    def test_post_with_spaces_in_name(self):
+        url = reverse('clone-hierarchy', kwargs={
+            'hierarchy_id': self.h.pk
+        })
+        r = self.client.post(url, {
+            'name': 'Test Case',
+            'base_url': '/pages/test-case/',
+        })
+
+        self.assertEqual(r.status_code, 302)
+
+        cloned_h = Hierarchy.objects.get(name='test-case')
+        self.assertEqual(cloned_h.base_url, '/pages/test-case/')
+        self.assertEqual(Case.objects.filter(hierarchy=cloned_h).count(), 1)
+
+        cloned_case = Case.objects.filter(hierarchy=cloned_h).first()
+        self.assertEqual(cloned_case.name, 'Test Case')
         self.assertEqual(cloned_case.description, self.case.description)
         self.assertEqual(cloned_case.cohort.count(), self.case.cohort.count())
         self.assertEqual(set(cloned_case.cohort.all()),

--- a/uelc/mixins.py
+++ b/uelc/mixins.py
@@ -47,17 +47,19 @@ class SectionMixin(object):
 
 class DynamicHierarchyMixin(object):
     def dispatch(self, *args, **kwargs):
-        name = kwargs.pop('hierarchy_name', None)
-        if name is None:
-            msg = "No hierarchy named %s found" % name
+        slugname = kwargs.pop('hierarchy_name', None)
+        if slugname is None:
+            return HttpResponseNotFound('hierarchy_name is None')
+
+        self.hierarchy_name = slugname
+        url = '/pages/{}/'.format(slugname)
+        try:
+            h = Hierarchy.objects.get(base_url=url)
+            self.hierarchy_base = h.base_url
+        except Hierarchy.DoesNotExist:
+            msg = "No hierarchy with url %s found" % url
             return HttpResponseNotFound(msg)
-        else:
-            self.hierarchy_name = name
-            try:
-                self.hierarchy_base = Hierarchy.objects.get(name=name).base_url
-            except Hierarchy.DoesNotExist:
-                msg = "No hierarchy named %s found" % name
-                return HttpResponseNotFound(msg)
+
         return super(DynamicHierarchyMixin, self).dispatch(*args, **kwargs)
 
 


### PR DESCRIPTION
When looking up hierarchies in the DynamicHierarchyMixin, I'm
looking at their base_url rather than their name.

Also, the hierarchy's name should be the slugified name, present
in the base_url, while the more human-readable name gets passed
to the created Case.

These changes are to prevent the user's choice of the hierarchy
name from having any effect on how the DynamicHierarchyMixin behaves,
only the base_url should determine that.