### PR TITLE
Always slugify cloned hierarchy name to prevent duplicates

### DIFF
--- a/uelc/main/forms.py
+++ b/uelc/main/forms.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
+from django.utils.text import slugify
+from pagetree.forms import CloneHierarchyForm
 from uelc.main.models import UserProfile, Cohort
 
 
@@ -40,6 +42,15 @@ class CreateHierarchyForm(forms.Form):
         widget=forms.widgets.Input(
             attrs={'class': 'add-hierarchy-name',
                    'required': True}))
+
+
+class UELCCloneHierarchyForm(CloneHierarchyForm):
+    def clean(self):
+        cleaned_data = super(UELCCloneHierarchyForm, self).clean()
+        slugname = slugify(self.cleaned_data['name'])
+        self.data['name'] = slugname
+        self.cleaned_data['name'] = slugname
+        return cleaned_data
 
 
 class EditUserPassForm(forms.Form):

--- a/uelc/main/tests/test_views.py
+++ b/uelc/main/tests/test_views.py
@@ -918,12 +918,22 @@ class CloneHierarchyWithCasesViewTest(TestCase):
 
         self.assertEqual(r.status_code, 302)
 
-        cloned_h = Hierarchy.objects.get(name='Test Case')
+        self.assertEqual(
+            Hierarchy.objects.get(base_url='/pages/test-case/'),
+            Hierarchy.objects.get(name='test-case'))
+        self.assertEqual(
+            Hierarchy.objects.filter(base_url='/pages/test-case/').count(),
+            1)
+        self.assertEqual(
+            Hierarchy.objects.filter(name='test-case').count(),
+            1)
+
+        cloned_h = Hierarchy.objects.get(name='test-case')
         self.assertEqual(cloned_h.base_url, '/pages/test-case/')
         self.assertEqual(Case.objects.filter(hierarchy=cloned_h).count(), 1)
 
         cloned_case = Case.objects.filter(hierarchy=cloned_h).first()
-        self.assertEqual(cloned_case.name, 'Test Case')
+        self.assertEqual(cloned_case.name, 'test-case')
         self.assertEqual(cloned_case.description, self.case.description)
         self.assertEqual(cloned_case.cohort.count(), self.case.cohort.count())
         self.assertEqual(set(cloned_case.cohort.all()),

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -33,7 +33,8 @@ from uelc.main.models import (
     LibraryItem)
 from uelc.main.forms import (
     CreateUserForm, CreateHierarchyForm,
-    EditUserPassForm, CaseAnswerForm)
+    EditUserPassForm, CaseAnswerForm, UELCCloneHierarchyForm
+)
 
 from curveball.models import Curveball, CurveballBlock
 
@@ -1267,6 +1268,7 @@ class DeleteCaseAnswerView(LoggedInMixinAdmin,
 
 
 class CloneHierarchyWithCasesView(CloneHierarchyView):
+    form_class = UELCCloneHierarchyForm
 
     def form_valid(self, form):
         name = form.cleaned_data['name']


### PR DESCRIPTION
The name needs to match the base_url.. I forgot that when making some
changes.