### PR TITLE
Address clone form 'name' problem - PMT #104940

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ django-ga-context==0.1.0
 django-impersonate==0.9.2
 django-registration-redux==1.2
 django-treebeard==3.0
-django-pagetree==1.1.10
+django-pagetree==1.1.11
 django-quizblock==1.1.4
 django-markwhat==1.4
 django-pageblocks==1.0.3

--- a/uelc/mixins.py
+++ b/uelc/mixins.py
@@ -50,12 +50,11 @@ class DynamicHierarchyMixin(object):
         slugname = kwargs.pop('hierarchy_name', None)
         if slugname is None:
             return HttpResponseNotFound('hierarchy_name is None')
-
-        self.hierarchy_name = slugname
         url = '/pages/{}/'.format(slugname)
         try:
             h = Hierarchy.objects.get(base_url=url)
             self.hierarchy_base = h.base_url
+            self.hierarchy_name = h.name
         except Hierarchy.DoesNotExist:
             msg = "No hierarchy with url %s found" % url
             return HttpResponseNotFound(msg)


### PR DESCRIPTION
The main problem here was in DynamicHierarchyMixin, and I've added more
thorough testing to how the clone form behaves. The problem was that
DynamicHierarchyMixin was treating a slugified version of the base_url
as the hierarchy's name, using that to look it up, which triggered
pagetree to create a new hierarchy if it didn't exist. As a result, the
clone form would create *two* hierarchies, one with all the data, and
one empty one, unless the name and the base_url were both the same,
i.e.: name: 'case-one', base_url: '/pages/base-url/'

The other bullet point in this PMT has already been implemented. You
don't need to type `/pages/` around the base_url, you can just give it a
slug.