### PR TITLE
Remove contextlib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,6 @@ boto==2.40.0
 django-storages-redux==1.3.2
 python-dateutil==2.5.3
 pyzmq==15.2.0
-contextlib2==0.5.3
 
 djangowind==0.14.3
 sorl==3.1


### PR DESCRIPTION
It looks like we don't need to include this package in python 2.7:
https://docs.python.org/2.7/library/contextlib.html