### PR TITLE
Use input instead of textarea for image name

### DIFF
--- a/uelc/main/admin.py
+++ b/uelc/main/admin.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
@@ -37,6 +38,13 @@ class FlatPageCustom(FlatPageAdmin):
         models.TextField: {'widget': CKEditorWidget}
     }
 
+
+class ImageUploadItemAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        models.TextField: {'widget': forms.widgets.TextInput}
+    }
+
+
 # Re-register UserAdmin
 admin.site.unregister(User)
 admin.site.register(User, UserAdmin)
@@ -50,7 +58,7 @@ admin.site.register(CaseQuiz)
 admin.site.register(CaseAnswer)
 admin.site.register(Cohort)
 admin.site.register(LibraryItem)
-admin.site.register(ImageUploadItem)
+admin.site.register(ImageUploadItem, ImageUploadItemAdmin)
 admin.site.register(GateBlock)
 admin.site.unregister(FlatPage)
 admin.site.register(FlatPage, FlatPageCustom)


### PR DESCRIPTION
This makes it more obvious what's expected for this field.

![2016-06-23-095739_505x194_scrot](https://cloud.githubusercontent.com/assets/59292/16305702/f34edd6e-3928-11e6-829d-8fab6eb84b60.png)
