### PR TITLE
Management Panel - user page optimization

### DIFF
--- a/uelc/main/models.py
+++ b/uelc/main/models.py
@@ -22,6 +22,9 @@ class Cohort(models.Model):
         blank=False,
         unique=True)
 
+    class Meta:
+        ordering = ['name']
+
     def __unicode__(self):
         return self.name
 
@@ -76,6 +79,15 @@ class Cohort(models.Model):
                 empty_label=None)
         return EditForm()
 
+    @classmethod
+    def make_choices(cls):
+        key = 'cohorts'
+        choices = cache.get(key)
+        if choices is None:
+            choices = [(c.id, c.name) for c in Cohort.objects.all()]
+            cache.set(key, choices, 60)
+        return choices
+
 
 class UserProfile(models.Model):
     PROFILE_CHOICES = (
@@ -92,7 +104,13 @@ class UserProfile(models.Model):
         null=True)
 
     def edit_form(self):
+        cohort_id = self.cohort.id if self.cohort else None
+
         class EditForm(forms.Form):
+            def __init__(self):
+                super(EditForm, self).__init__()
+                self.fields['cohort'].choices = Cohort.make_choices()
+
             username = forms.CharField(
                 widget=forms.widgets.Input(
                     attrs={'class': 'edit-user-username'}),
@@ -103,11 +121,11 @@ class UserProfile(models.Model):
                 widget=forms.Select(
                     attrs={'class': 'create-user-profile', 'required': True}),
                 choices=UserProfile.PROFILE_CHOICES)
-            cohort = forms.ModelChoiceField(
-                initial=self.cohort,
+            cohort = forms.ChoiceField(
+                initial=cohort_id,
                 widget=forms.Select(
                     attrs={'class': 'cohort-select'}),
-                queryset=Cohort.objects.all().order_by('name'),)
+                choices=[])
         return EditForm()
 
     def set_image_upload_permissions(self, user):

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -1182,7 +1182,8 @@ class UELCAdminUserView(LoggedInMixinAdmin,
         cohortmodel = Cohort
         create_user_form = CreateUserForm
         create_hierarchy_form = CreateHierarchyForm
-        users = User.objects.all().order_by('username')
+        users = User.objects.all().order_by('username').select_related(
+            'profile__cohort')
         hierarchies = Hierarchy.objects.all()
         cases = Case.objects.all()
         cohorts = Cohort.objects.all().order_by('name')


### PR DESCRIPTION
* Initial: 14,400ms, 890 queries
* In main.views.UELCAdminUserView -- To the Users query, add a .select_related('profile__cohort'): 8087ms, 282 queries
   * This selects both the profile & the cohort
* In main.models.UserProfile.edit_form, the use of a ModelChoiceForm is inherently inefficient, and the queryset is difficult to cache. Swapping out for a regular Choice Field and cached choices.
   * 5,110ms, 28 queries

The real issue here is the inline rendering of the User EditForm ad nauseum. This hammers the DOM and creates a very slow page rendering. I'm going to add pagination next, which should minimize this issue.