### PR TITLE
generate simpler windsock tokens

### DIFF
--- a/uelc/main/helper_functions.py
+++ b/uelc/main/helper_functions.py
@@ -126,7 +126,7 @@ def fresh_token(request, hierarchy_name=None):
     return HttpResponse(
         json.dumps(
             dict(hierarchy=hierarchy.as_dict(),
-                 token=gen_token(request, hierarchy.name),
+                 token=gen_token(request, "module_%02d" % hierarchy.pk),
                  websockets_base=settings.WINDSOCK_WEBSOCKETS_BASE)),
         content_type='applicaton/json')
 

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -582,6 +582,7 @@ class FacilitatorView(LoggedInFacilitatorMixin,
             gate_section.sort(cmp=lambda x, y: cmp(x[3], y[3]))
             user_sections.append([user, gate_section, user_last_location])
 
+        token = gen_token(request, "module_%02d" % section.hierarchy.pk)
         context = dict(
             is_facilitator_view=True,
             section=section,
@@ -589,7 +590,7 @@ class FacilitatorView(LoggedInFacilitatorMixin,
             modules=hierarchy.get_root().get_children(),
             case=case,
             websockets_base=settings.WINDSOCK_WEBSOCKETS_BASE,
-            token=gen_token(request, section.hierarchy.name),
+            token=token,
         )
 
         return render(request, self.template_name, context)


### PR DESCRIPTION
PMT #109157

Using the hierarchy name is bad because it can (and apparently
frequently does) include a ':' which windsock uses as a delimiter for
tokens. The token gets included directly in the template without any
escaping, so it would also break at the JS level if the name of a
hierarchy happened to include a single quote.

This changes it to just use a simpler alphanumeric form.