### PR TITLE
Zmq proxy

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from splinter import Browser
 
 from uelc.main.tests.factories import AdminUpFactory, UELCModuleFactory
-from uelc.main.views import zmq_context
 
 
 def before_all(context):
@@ -23,4 +22,3 @@ def after_step(context, step):
 def after_all(context):
     context.browser.quit()
     del context.browser
-    zmq_context.term()

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -133,7 +133,6 @@ class UELCPageView(LoggedInMixin,
 
     def notify_facilitators(self, request, path, notification):
         user = get_object_or_404(User, pk=request.user.pk)
-        broker = settings.BROKER_PROXY()
         msg = dict()
 
         if(notification['message'] == 'Decision Submitted'):
@@ -163,6 +162,7 @@ class UELCPageView(LoggedInMixin,
                  (settings.ZMQ_APPNAME, self.section.hierarchy.name),
                  content=json.dumps(msg))
 
+        broker = settings.BROKER_PROXY()
         broker.send(json.dumps(e))
 
     def check_user(self, request, path):
@@ -350,8 +350,6 @@ class SubmitSectionView(LoggedInMixin,
     template_name = 'pagetree/page.html'
 
     def notify_facilitators(self, request, section, notification):
-        broker = settings.BROKER_PROXY()
-
         msg = dict(
             userId=request.user.id,
             sectionPk=section.pk,
@@ -361,6 +359,7 @@ class SubmitSectionView(LoggedInMixin,
                  (settings.ZMQ_APPNAME, section.hierarchy.name),
                  content=json.dumps(msg))
 
+        broker = settings.BROKER_PROXY()
         broker.send(json.dumps(e))
 
     def post(self, request):
@@ -410,7 +409,6 @@ class FacilitatorView(LoggedInFacilitatorMixin,
             pass
 
     def notify_group_user(self, section, user, notification):
-        broker = settings.BROKER_PROXY()
         msg = dict(userId=user.id,
                    username=user.username,
                    hierarchy=section.hierarchy.name,
@@ -420,10 +418,10 @@ class FacilitatorView(LoggedInFacilitatorMixin,
         e = dict(address="%s.%d" %
                  (settings.ZMQ_APPNAME, section.pk),
                  content=json.dumps(msg))
+        broker = settings.BROKER_PROXY()
         broker.send(json.dumps(e))
 
     def notify_facilitator(self, request, section, user, msg):
-        broker = settings.BROKER_PROXY()
         notification = dict(
             data='',
             message=msg)
@@ -436,6 +434,7 @@ class FacilitatorView(LoggedInFacilitatorMixin,
                  (settings.ZMQ_APPNAME, section.hierarchy.name),
                  content=json.dumps(msg))
 
+        broker = settings.BROKER_PROXY()
         broker.send(json.dumps(e))
 
     def post_curveball_select(self, request):

--- a/uelc/main/views.py
+++ b/uelc/main/views.py
@@ -133,7 +133,7 @@ class UELCPageView(LoggedInMixin,
 
     def notify_facilitators(self, request, path, notification):
         user = get_object_or_404(User, pk=request.user.pk)
-        zmq_proxy = settings.ZMQ_PROXY()
+        broker = settings.BROKER_PROXY()
         msg = dict()
 
         if(notification['message'] == 'Decision Submitted'):
@@ -163,7 +163,7 @@ class UELCPageView(LoggedInMixin,
                  (settings.ZMQ_APPNAME, self.section.hierarchy.name),
                  content=json.dumps(msg))
 
-        zmq_proxy.send(json.dumps(e))
+        broker.send(json.dumps(e))
 
     def check_user(self, request, path):
         if not request.user.is_superuser and self.section.get_depth() == 2:
@@ -350,7 +350,7 @@ class SubmitSectionView(LoggedInMixin,
     template_name = 'pagetree/page.html'
 
     def notify_facilitators(self, request, section, notification):
-        zmq_proxy = settings.ZMQ_PROXY()
+        broker = settings.BROKER_PROXY()
 
         msg = dict(
             userId=request.user.id,
@@ -361,7 +361,7 @@ class SubmitSectionView(LoggedInMixin,
                  (settings.ZMQ_APPNAME, section.hierarchy.name),
                  content=json.dumps(msg))
 
-        zmq_proxy.send(json.dumps(e))
+        broker.send(json.dumps(e))
 
     def post(self, request):
         user = request.user
@@ -410,7 +410,7 @@ class FacilitatorView(LoggedInFacilitatorMixin,
             pass
 
     def notify_group_user(self, section, user, notification):
-        zmq_proxy = settings.ZMQ_PROXY()
+        broker = settings.BROKER_PROXY()
         msg = dict(userId=user.id,
                    username=user.username,
                    hierarchy=section.hierarchy.name,
@@ -420,10 +420,10 @@ class FacilitatorView(LoggedInFacilitatorMixin,
         e = dict(address="%s.%d" %
                  (settings.ZMQ_APPNAME, section.pk),
                  content=json.dumps(msg))
-        zmq_proxy.send(json.dumps(e))
+        broker.send(json.dumps(e))
 
     def notify_facilitator(self, request, section, user, msg):
-        zmq_proxy = settings.ZMQ_PROXY()
+        broker = settings.BROKER_PROXY()
         notification = dict(
             data='',
             message=msg)
@@ -436,7 +436,7 @@ class FacilitatorView(LoggedInFacilitatorMixin,
                  (settings.ZMQ_APPNAME, section.hierarchy.name),
                  content=json.dumps(msg))
 
-        zmq_proxy.send(json.dumps(e))
+        broker.send(json.dumps(e))
 
     def post_curveball_select(self, request):
         '''Show the facilitator their choices for the curveball,

--- a/uelc/settings_shared.py
+++ b/uelc/settings_shared.py
@@ -129,7 +129,7 @@ CACHES = {
     }
 }
 
-ZMQ_PROXY = zmqproxy.ZMQProxy
+BROKER_PROXY = zmqproxy.ZMQProxy
 
 if 'test' in sys.argv or 'jenkins' in sys.argv or 'behave' in sys.argv:
     CACHES = {

--- a/uelc/settings_shared.py
+++ b/uelc/settings_shared.py
@@ -138,3 +138,4 @@ if 'test' in sys.argv or 'jenkins' in sys.argv or 'behave' in sys.argv:
             'LOCATION': 'uelc',
         }
     }
+    BROKER_PROXY = zmqproxy.DummyProxy

--- a/uelc/settings_shared.py
+++ b/uelc/settings_shared.py
@@ -1,6 +1,7 @@
 # Django settings for uelc project.
 import os.path
 import sys
+import zmqproxy
 
 from ccnmtlsettings.shared import common
 
@@ -127,6 +128,9 @@ CACHES = {
         'LOCATION': 'uelc',
     }
 }
+
+ZMQ_PROXY = zmqproxy.ZMQProxy
+
 if 'test' in sys.argv or 'jenkins' in sys.argv or 'behave' in sys.argv:
     CACHES = {
         'default': {

--- a/uelc/zmqproxy.py
+++ b/uelc/zmqproxy.py
@@ -1,0 +1,33 @@
+import sys
+import zmq
+from django.conf import settings
+
+
+zmq_context = zmq.Context()
+
+
+def behave_socket_open(socket):
+    """Make the socket behave-compatible. :-/"""
+    if sys.argv[1:2] == ['behave']:
+        socket.linger = 0
+
+
+def behave_socket_recv(socket):
+    """ZMQ socket.recv() that doesn't hang on behave"""
+    # TODO: behave hangs on socket.recv()
+    if sys.argv[1:2] == ['behave']:
+        try:
+            socket.recv(zmq.NOBLOCK)
+        except zmq.ZMQError:
+            pass
+    else:
+        socket.recv()
+
+
+class ZMQProxy():
+    def send(self, msg):
+        socket = self.zmq_context.socket(zmq.REQ)
+        behave_socket_open(socket)
+        socket.connect(settings.WINDSOCK_BROKER_URL)
+        socket.send(msg)
+        behave_socket_recv(socket)

--- a/uelc/zmqproxy.py
+++ b/uelc/zmqproxy.py
@@ -31,3 +31,9 @@ class ZMQProxy():
         socket.connect(settings.WINDSOCK_BROKER_URL)
         socket.send(msg)
         behave_socket_recv(socket)
+
+
+class DummyProxy():
+    def send(self, msg):
+        # we do nothing
+        pass

--- a/uelc/zmqproxy.py
+++ b/uelc/zmqproxy.py
@@ -7,7 +7,7 @@ zmq_context = zmq.Context()
 
 class ZMQProxy():
     def send(self, msg):
-        socket = self.zmq_context.socket(zmq.REQ)
+        socket = zmq_context.socket(zmq.REQ)
         socket.connect(settings.WINDSOCK_BROKER_URL)
         socket.send(msg)
 

--- a/uelc/zmqproxy.py
+++ b/uelc/zmqproxy.py
@@ -1,4 +1,3 @@
-import sys
 import zmq
 from django.conf import settings
 
@@ -6,31 +5,11 @@ from django.conf import settings
 zmq_context = zmq.Context()
 
 
-def behave_socket_open(socket):
-    """Make the socket behave-compatible. :-/"""
-    if sys.argv[1:2] == ['behave']:
-        socket.linger = 0
-
-
-def behave_socket_recv(socket):
-    """ZMQ socket.recv() that doesn't hang on behave"""
-    # TODO: behave hangs on socket.recv()
-    if sys.argv[1:2] == ['behave']:
-        try:
-            socket.recv(zmq.NOBLOCK)
-        except zmq.ZMQError:
-            pass
-    else:
-        socket.recv()
-
-
 class ZMQProxy():
     def send(self, msg):
         socket = self.zmq_context.socket(zmq.REQ)
-        behave_socket_open(socket)
         socket.connect(settings.WINDSOCK_BROKER_URL)
         socket.send(msg)
-        behave_socket_recv(socket)
 
 
 class DummyProxy():


### PR DESCRIPTION
Put access to the ZMQ windsock broker behind a proxy object. This makes the application code a little cleaner as ZMQ just becomes an implementation detail that it doesn't have to deal with.

It also allows us to dummy it out cleanly for unit tests and behave tests, instead of mucking with sockets to keep things from hanging.

This will probably also make it simpler to extract the routing address logic later.