### PR TITLE
add windsock connection smoketest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,8 @@ python-dateutil==2.6.0
 pyzmq==16.0.2
 contextlib2==0.5.4
 
+websocket_client==0.40.0
+
 djangowind==0.16.1
 sorl==3.1
 typogrify==2.0.7

--- a/uelc/main/smoke.py
+++ b/uelc/main/smoke.py
@@ -1,8 +1,10 @@
-from smoketest import SmokeTest
-from django.contrib.auth.models import User
-import zmq
-from django.conf import settings
 import json
+import zmq
+from django.contrib.auth.models import User
+from django.conf import settings
+from smoketest import SmokeTest
+from websocket import create_connection
+from .helper_functions import gen_token
 
 zmq_context = zmq.Context()
 
@@ -53,3 +55,26 @@ class BrokerConnectivity(SmokeTest):
             self.assertTrue(False)
         finally:
             socket.close()
+
+
+class DummyUser(object):
+    username = "smoketest"
+
+
+class DummyRequest(object):
+    def __init__(self):
+        self.user = DummyUser()
+        self.META = {'HTTP_X_FORWARDED_FOR': '127.0.0.1'}
+
+
+class WindsockConnectivity(SmokeTest):
+    def test_connect(self):
+        try:
+            r = DummyRequest()
+            token = gen_token(r, "smoketest")
+            ws = create_connection(
+                settings.WINDSOCK_WEBSOCKETS_BASE + "?token=" + token)
+            ws.close()
+            self.assertTrue(True)
+        except:
+            self.assertTrue(False)


### PR DESCRIPTION
We already had a smoketest that checked that it could send a message to
the broker. This adds another smoketest that actually generates a token
and makes a connection to the websockets server. This way, if windsock
is down, or if something changes in the token generation that makes
tokens invalid (eg, if clocks get out of skew), the smoketests will
fail.

I already did the same thing (and self-merged so I could be sure) for
tala:

https://github.com/ccnmtl/tala/pull/292