### PR TITLE
Reset User Progress

### DIFF
--- a/media/js/uelc_admin/uelc_facilitator.js
+++ b/media/js/uelc_admin/uelc_facilitator.js
@@ -12,6 +12,10 @@ UELCAdmin = {
                     this.setCurveball);
             jQuery('#confirm-curveball-modal .cancel-curveball').click(
                     this.cancelCurveball);
+
+            jQuery('button.reset-progress').click(this.confirmResetProgress);
+            jQuery('#confirm-reset-progress-modal .btn-danger').click(
+                    this.resetProgress);
         };
         this.setChoicesOnParts = function() {
             jQuery('.user-part2').each(function() {
@@ -185,6 +189,27 @@ UELCAdmin = {
                     window.open(destination, '_blank');
                 });
             });
+        };
+        this.confirmResetProgress = function(evt) {
+            evt.preventDefault();
+            var userId = jQuery(evt.currentTarget).data('user-id');
+            var username = jQuery(evt.currentTarget).data('username');
+
+            var $modal = jQuery('#confirm-reset-progress-modal');
+            $modal.find('input[name="user-id"]').val(userId);
+            $modal.find('span.username').html(username);
+            $modal.find('.loading-spinner').addClass('hidden');
+            $modal.modal('show');
+            return false;
+        };
+        this.resetProgress = function(evt) {
+            // serialize data from the curveball form AND
+            // tack on data from the previous gateblock gate-button frm
+            var $modal = jQuery('#confirm-reset-progress-modal');
+            $modal.find('.loading-spinner').removeClass('hidden');
+
+            var $frm = $modal.find('form');
+            $frm.submit();
         };
 
         this.init();

--- a/uelc/main/helper_functions.py
+++ b/uelc/main/helper_functions.py
@@ -8,12 +8,13 @@ import time
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404
 from pagetree.generic.views import generic_instructor_page, generic_edit_page
-from pagetree.models import Hierarchy, Section
+from pagetree.models import Hierarchy, Section, PageBlock
 
 from gate_block.models import GateSubmission
 from uelc.main.models import CaseMap, Case, CaseAnswer
@@ -309,3 +310,10 @@ def is_next_curveball(section):
     else:
         cache.set(key, False)
         return False
+
+
+def content_blocks_by_hierarchy_and_class(hierarchy, cls):
+    ctype = ContentType.objects.get_for_model(cls)
+    return PageBlock.objects.filter(
+        content_type__pk=ctype.pk, section__hierarchy=hierarchy).values_list(
+            'object_id', flat=True)

--- a/uelc/main/tests/factories.py
+++ b/uelc/main/tests/factories.py
@@ -253,7 +253,8 @@ class UELCModuleFactory(object):
                             },
                             {
                                 'block_type': 'Curveball Block',
-                                'description': 'Curveball description',
+                                'label': 'curveball-block-1',
+                                'description': 'curveball description 1',
                                 'curveball_one': CurveballFactory(),
                                 'curveball_two': CurveballFactory(),
                                 'curveball_three': CurveballFactory(),
@@ -300,7 +301,7 @@ class UELCModuleFactory(object):
         # Assert that the Quiz imported correctly.
         assert CurveballBlock.objects.count() == 1
         cb = CurveballBlock.objects.first()
-        assert cb.description == 'Curveball description'
+        assert cb.description == 'curveball description 1'
 
         root.add_child_section_from_dict({
             'label': 'Part 2 Choice 1',
@@ -317,8 +318,8 @@ class UELCModuleFactory(object):
                     'slug': 'curve-ball',
                     'pageblocks': [{
                         'block_type': 'Curveball Block',
-                        'label': 'Curveball Block',
-                        'description': 'Curveball description',
+                        'label': 'curveball-block-2',
+                        'description': 'curveball description 2',
                         'curveball_one': CurveballFactory(),
                         'curveball_two': CurveballFactory(),
                         'curveball_three': CurveballFactory(),
@@ -347,3 +348,4 @@ class UELCModuleFactory(object):
             }]
         })
         self.root = root
+        self.case = case

--- a/uelc/main/tests/test_helper_functions.py
+++ b/uelc/main/tests/test_helper_functions.py
@@ -4,13 +4,15 @@ from pagetree.tests.factories import RootSectionFactory
 from quizblock.models import Submission, Question, Response
 from quizblock.tests.test_models import FakeReq
 
+from curveball.models import CurveballBlock
 from gate_block.models import GateBlock
 from uelc.main.helper_functions import (
     admin_ajax_page_submit, admin_ajax_reset_page,
     page_submit, reset_page, get_user_map, get_user_last_location,
     gen_fac_token, gen_group_token,
     get_vals_from_casemap, get_partchoice_by_usermap, get_p1c1, can_show,
-    p1pre, is_curveball, is_decision_block)
+    p1pre, is_curveball, is_decision_block,
+    content_blocks_by_hierarchy_and_class)
 from uelc.main.models import CaseQuiz, Cohort, Case, CaseMap, CaseAnswer
 from uelc.main.tests.factories import (
     CaseFactory, CaseMapFactory, GroupUpFactory, GroupUserFactory,
@@ -153,6 +155,16 @@ class TestUtils(TestCase):
     def setUp(self):
         UELCModuleFactory()
         self.h = Hierarchy.objects.get(name='case-test')
+
+    def test_content_blocks_by_hierarchy_and_class(self):
+        ids = content_blocks_by_hierarchy_and_class(self.h, CurveballBlock)
+
+        blks = PageBlock.objects.filter(
+            label__in=['curveball-block-1', 'curveball-block-2']).values_list(
+                'object_id', flat=True)
+
+        self.assertEquals(ids.count(), 2)
+        self.assertEquals(list(ids), list(blks))
 
     def test_gen_fac_token(self):
         r = RequestFactory()

--- a/uelc/templates/pagetree/facilitator.html
+++ b/uelc/templates/pagetree/facilitator.html
@@ -42,16 +42,12 @@
                         {% endif %}
                     >
                         <div class="panel-body">
-                            <h3 class="text-center">
-                                <h3 class="facilitator-usrnm">Group {{u.0}}</h3> 
-                            </h3>
+                            <h3 class="facilitator-usrnm">Group {{u.0}}</h3>
+                            <button class="btn btn-xs btn-default pull-left reset-progress"
+                                data-user-id="{{u.0.id}}" data-username="{{u.0}}">
+                                reset
+                            </button>
                             <div class="user-icon
-                               {# crazy but works #}
-                               {% for sec in u.1 %}
-                               {% if sec.0.pk == u.2.id %}
-                               hidden
-                               {% endif %}
-                               {% endfor %}">
                                 <span class="glyphicon glyphicon-user pull-right" aria-hidden="true"></span>
                             </div>
                         </div>
@@ -181,4 +177,33 @@
         </div>
     </div>
 </div>
+
+<div id="confirm-reset-progress-modal" class="modal fade in" tabindex="-1"
+    role="dialog" aria-labelledby="Reset Progress" aria-hidden="false">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">
+                   Confirm Reset
+                </h4>
+            </div>
+            <div class="modal-body">
+                <form method="post" action='{% url "reset-user-case-progress" case.id %}'>
+                    {% csrf_token %}
+                    <input type="hidden" name="user-id" value="" />
+                    <p>Are you sure? This action will completely reset <b><span class="username"></span>'s</b> progress.</p>
+                    <p><b>Important</b>: Before proceeding, direct the group user to exit the 
+                    session by clicking the Eldex logo in the top left of their screen. Once the progress is cleared,
+                    direct the user to reenter the session</p>
+                    <div class="hidden loading-spinner"></div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger">Reset Progress</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 {% endblock %}

--- a/uelc/urls.py
+++ b/uelc/urls.py
@@ -1,13 +1,14 @@
-import django.contrib.auth.views
-import djangowind.views
 import os.path
-import uelc.main.helper_functions
 
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.conf import settings
+import django.contrib.auth.views
 from django.views.generic import TemplateView
+import djangowind.views
+
 from uelc.main import views
+import uelc.main.helper_functions
 from uelc.main.views import (
     UELCPageView, UELCEditView, FacilitatorView, UELCAdminView,
     UELCAdminCohortView, UELCAdminCreateHierarchyView,
@@ -17,8 +18,9 @@ from uelc.main.views import (
     UELCAdminDeleteCohortView, UELCAdminDeleteCaseView,
     UELCAdminCreateCaseView, UELCAdminDeleteUserView,
     AddCaseAnswerToQuestionView, EditCaseAnswerView, DeleteCaseAnswerView,
-    SubmitSectionView, CloneHierarchyWithCasesView
-)
+    SubmitSectionView, CloneHierarchyWithCasesView, ResetUserCaseProgress)
+
+
 admin.autodiscover()
 
 site_media_root = os.path.join(os.path.dirname(__file__), "../media")
@@ -88,6 +90,8 @@ urlpatterns = [
     url(r'^pages/(?P<hierarchy_name>[-\w]+)/edit/(?P<path>.*)$',
         UELCEditView.as_view()),
     url(r'^submit_section/', SubmitSectionView.as_view()),
+    url(r'^reset/(?P<case_id>\d+)/$',
+        ResetUserCaseProgress.as_view(), name='reset-user-case-progress'),
     url(r'^pages/(?P<hierarchy_name>[-\w]+)/instructor/(?P<path>.*)$',
         uelc.main.helper_functions.instructor_page),
     url(r'^facilitator/fresh_token/$', uelc.main.helper_functions.fresh_token),


### PR DESCRIPTION
Allow facilitator to reset a user's progress as he navigates through an interactive session. This is designed to be an escape hatch in case there are any technical issues or freezes that cannot be resolved.

* helper_functions content_blocks_by_hierarchy_and_class - utility to retrieve underlying pageblock content objects.
* ResetUserCaseProgress - delete all state objects associated with this case
* clientside confirmation & interaction
* tests