### PR TITLE
Fix hierarchy cloning bug with duplicate base_url - PMT #104909

### DIFF
--- a/uelc/main/forms.py
+++ b/uelc/main/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User
 from pagetree.forms import CloneHierarchyForm
+from pagetree.models import Hierarchy
 from uelc.main.models import UserProfile, Cohort
 
 
@@ -60,6 +61,10 @@ class UELCCloneHierarchyForm(CloneHierarchyForm):
             # base_url isn't in the recognizable format, so assume it's
             # a slug.
             base_url = '/pages/%s/' % base_url
+            if Hierarchy.objects.filter(base_url=base_url).exists():
+                raise forms.ValidationError(
+                    'There\'s already a hierarchy with ' +
+                    'the base_url: {}'.format(base_url))
             self.cleaned_data['base_url'] = base_url
 
         return self.cleaned_data

--- a/uelc/main/tests/test_views.py
+++ b/uelc/main/tests/test_views.py
@@ -1023,6 +1023,36 @@ class CloneHierarchyWithCasesViewTest(TestCase):
         self.assertEqual(set(cloned_case.cohort.all()),
                          set(self.case.cohort.all()))
 
+    def test_post_with_duplicate_base_url(self):
+        url = reverse('clone-hierarchy', kwargs={
+            'hierarchy_id': self.h.pk
+        })
+        r = self.client.post(url, {
+            'name': 'Some Random Name',
+            'base_url': self.h.base_url,
+        }, follow=True)
+
+        self.assertEqual(r.status_code, 200)
+
+        self.assertEqual(Hierarchy.objects.count(), 1)
+        self.assertContains(
+            r,
+            'already a hierarchy with the base_url: {}'.format(
+                self.h.base_url))
+
+        r = self.client.post(url, {
+            'name': 'Some Random Name',
+            'base_url': 'case-test',
+        }, follow=True)
+
+        self.assertEqual(r.status_code, 200)
+
+        self.assertEqual(Hierarchy.objects.count(), 1)
+        self.assertContains(
+            r,
+            'already a hierarchy with the base_url: {}'.format(
+                self.h.base_url))
+
 
 class UELCPageViewTest(TestCase):
 


### PR DESCRIPTION
Fixes a bug that can occur if you use the clone form to clone a
hierarchy that has the base_url `/pages/case-three/` using the slug:
`case-three`:
> MultipleObjectsReturned at /pages/case-three/
> get() returned more than one Hierarchy -- it returned 2!