### PR TITLE
Explicitly import django.views.static.serve

### DIFF
--- a/uelc/urls.py
+++ b/uelc/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 import django.contrib.auth.views
 from django.views.generic import TemplateView
+from django.views.static import serve
 import djangowind.views
 
 from uelc.main import views
@@ -79,7 +80,7 @@ urlpatterns = [
     url(r'^stats/$', TemplateView.as_view(template_name="stats.html")),
     url(r'smoketest/', include('smoketest.urls')),
     url(r'infranil/', include('infranil.urls')),
-    url(r'^uploads/(?P<path>.*)$', django.views.static.serve,
+    url(r'^uploads/(?P<path>.*)$', serve,
         {'document_root': settings.MEDIA_ROOT}),
     url(r'^pagetree/clone_hierarchy/(?P<hierarchy_id>\d+)/$',
         CloneHierarchyWithCasesView.as_view(), name='clone-hierarchy'),


### PR DESCRIPTION
This fixes an error I'm seeing in my dev environment:

    AttributeError: 'module' object has no attribute 'static'