### PR TITLE
Create cohort + users on clone - PMT #109854

### DIFF
--- a/uelc/main/utils.py
+++ b/uelc/main/utils.py
@@ -1,6 +1,15 @@
+import random
+import string
 from django.core.cache import cache
 
 
 def clear_handler_cache(node):
     cache.delete('uelc.{}.get_part_by_section'.format(node.pk))
     cache.delete('uelc.{}.is_next_curveball'.format(node.pk))
+
+
+def random_string(n):
+    """Generate a random string of length n."""
+    return ''.join(
+        random.choice(
+            string.ascii_uppercase + string.digits) for _ in range(n))

--- a/uelc/templates/pagetree/edit_page.html
+++ b/uelc/templates/pagetree/edit_page.html
@@ -99,6 +99,8 @@
 {% endblock %}
 
 {% block content %}
+    {% bootstrap_messages %}
+
 {% with section.is_root as is_root %}
 
 <h1>{{ section.label }}</h1>


### PR DESCRIPTION
Usernames are based on the cloned hierarchy's name, and passwords are
set to be the same as the username.

![2017-03-03-115125_951x350_scrot](https://cloud.githubusercontent.com/assets/59292/23560287/e859fb54-0007-11e7-9f43-32705e1df899.png)
