### PR TITLE
Decrease group name font size

### DIFF
--- a/uelc/templates/pagetree/facilitator.html
+++ b/uelc/templates/pagetree/facilitator.html
@@ -42,7 +42,7 @@
                         {% endif %}
                     >
                         <div class="panel-body">
-                            <h3 class="facilitator-usrnm">Group {{u.0}}</h3>
+                            <h4 class="facilitator-usrnm">Group {{u.0}}</h4>
                             <button class="btn btn-xs btn-default pull-left reset-progress"
                                 data-user-id="{{u.0.id}}" data-username="{{u.0}}">
                                 reset


### PR DESCRIPTION
The group names feel like they are taking over the facilitator view, so
I made them smaller.

before:
![2017-05-24-201037_282x256_scrot](https://cloud.githubusercontent.com/assets/59292/26430717/5a7ddbec-40bd-11e7-9524-991eeba1672f.png)

after:
![2017-05-24-201042_271x316_scrot](https://cloud.githubusercontent.com/assets/59292/26430721/61dc7e34-40bd-11e7-9bca-93fb94bb32bc.png)
