### PR TITLE
travis: remove behave step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 sudo: false
-addons:
-  firefox: "38.8.0esr"
 python:
   - "2.7.6"
 before_install:
@@ -14,6 +12,5 @@ install:
 script:
   - make flake8
   - make travis
-  - make behave
 notifications:
   slack: ccnmtl:GizSNscLWJLldjQrffB8mwgm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7.6"
-before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
 install:
   - pip install -U pip wheel
   - pip install -U setuptools


### PR DESCRIPTION
master is currently failing, making the travis test step not useful. Also, they're only able to run on a really old version of Firefox that no one's using anymore.

Because we have plans to slowly stop maintaining UELC, I think it's best to just remove the unstable behave step. We can still get use out of the basic unit tests.