### PR TITLE
Add missing dependency: futures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -132,5 +132,6 @@ bandit==1.5.1
 traceback2==1.4.0
 linecache2==1.0.0
 
+futures==3.3.0; python_version < '3'
 functools32==3.2.3-2
 entrypoints==0.3


### PR DESCRIPTION
Fixes error:

    import concurrent.futures
    ImportError: No module named concurrent.futures